### PR TITLE
Fix typo at task text

### DIFF
--- a/modules/20-hypertext/20-text-style/description.ru.yml
+++ b/modules/20-hypertext/20-text-style/description.ru.yml
@@ -53,7 +53,7 @@ instructions: |
   Добавьте в редактор фразу
 
   <div class="hexlet-basics-example my-3">
-    <span>Hexlet - hands-on programming courses</span>
+    <span>Hexlet — hands-on programming courses</span>
   </div>
 
   в которой слово «courses» сделайте жирным начертанием (физическая разметка), и выделите сочетание «programming» курсивом (логическая разметка). Не забудьте обернуть фразу в параграф


### PR DESCRIPTION
В решении учителя тире, а в задании с текстом, который надо вывести — дефис. Заменил дефис на тире.